### PR TITLE
部分テンプレートの実装

### DIFF
--- a/app/assets/stylesheets/_left-content.scss
+++ b/app/assets/stylesheets/_left-content.scss
@@ -3,6 +3,7 @@
   width: 300px;
   height: 100%;
   background-color: $leftbackcolor;
+  overflow-y: scroll;
 }
   .left-content-top{
     padding: 0 20px 20px 20px;
@@ -40,7 +41,7 @@
   list-style: none;
 }
 
-    .group{
+    .conversation{
       padding: 20px;
       color: $Whitecolor;
 

--- a/app/assets/stylesheets/_left-content.scss
+++ b/app/assets/stylesheets/_left-content.scss
@@ -3,8 +3,7 @@
   width: 300px;
   height: 100%;
   background-color: $leftbackcolor;
-  overflow-y: scroll;
-}
+
   .left-content-top{
     padding: 0 20px 20px 20px;
     height: 80px;
@@ -12,52 +11,54 @@
     background-color: #253141;
     float:left;
 
-    &__user-name{
-      height: 100px;
-      padding: 20px;
-      float:left;
-      font-size: 16px;
-      font-weight: bold;
-      color: white;
-      line-height: 60px;
-      letter-spacing: 2px;
-    }
-    &__set{
-      float: right;
-    }
-    &__setting{
-      color: white;
-      display: inline-block;
-      margin: 35px 0 15px 3px;
-      line-height: 28px;
-      font-size: 20px;
+     &__user-name{
+       line-height: 100px;
+       float: left;
+       font-size: 16px;
+       font-weight: bold;
+       color: $Whitecolor;
+     }
+
+     &__set{
+       line-height: 100px;
+       float: right;
+       color: $Whitecolor;
+       font-size: 20px;
+     }
+
+     &__setting{
+       color: $Whitecolor;
+       display: inline-block;
+      }
     }
   }
 
 .left-content-bottom{
-  margin: 0;
-  padding: 0;
+  float: left;
+  width: 300px;
+  height: calc(100% - 100px);
   color: $leftbackcolor;
-  list-style: none;
-}
+  overflow-y: scroll;
 
-    .conversation{
-      padding: 20px;
+  .conversation{
+
+    &__group{
+      padding: 20px 0 20px 20px;
       color: $Whitecolor;
 
-    &__link{
-      display: block;
-      color: $Whitecolor;
-      text-decoration: none;
-    }
+      &__link{
+        color: $Whitecolor;
+        text-decoration: none;
+      }
 
-    &__name {
-      display: inline-block;
-      font-size: 15px;
-      margin-bottom: 5px;
-    }
+      &__name {
+        font-size: 15px;
+      }
 
-    &__chat-message{
-      font-size: 11px;
+      &__chat-message{
+        padding-top: 5px;
+        font-size: 11px;
+      }
     }
+  }
   }

--- a/app/assets/stylesheets/_right-content.scss
+++ b/app/assets/stylesheets/_right-content.scss
@@ -1,14 +1,14 @@
 .right-content{
   float: left;
   position: relative;
-  height: 100%;
   width: calc(100% - 300px);
+  height: 100%;
   background-color: #fafafa;
 
   &__top{
-  height: 100px;
-  padding: 0 40px 0;
-  background-color: $Whitecolor;
+    height: 100px;
+    padding: 0 40px 0;
+    background-color: $Whitecolor;
 
     .chat-group{
       float: left;
@@ -17,18 +17,28 @@
       padding-top: 30px;
     }
 
-  .chat-members{
-    font-size: 12px;
-    color: #999999;
-    padding-top: 15px;
-    clear: left;
-  }
-  .right-content__edit{
-    float: right;
-    height: 100px;
+    .chat-members{
+      font-size: 12px;
+      color: #999999;
+      padding-top: 15px;
+      clear: left;
 
- .edit-link{
-  text-decoration: none;
+      &__members{
+        float: left;
+      }
+
+      &__names{
+        float: left;
+        padding-left: 10px;
+      }
+    }
+
+    .right-content__edit{
+      float: right;
+      height: 100px;
+
+    .edit-link{
+      text-decoration: none;
 
     .edit-button {
       margin: 28px 0;
@@ -41,7 +51,7 @@
         }
       }
     }
-    }
+  }
 
     &__middle{
       border-top: #eeeeee;
@@ -53,7 +63,7 @@
       .message{
         padding-top: 46px;
 
-       &__contents{
+        &__contents{
 
          &__sender{
            float: left;
@@ -75,22 +85,23 @@
            font-size: 14px;
            color: $messagescolor;
         }
-       }
       }
-     }
+    }
+  }
 
-   .chat-footer{
+  &__chat-footer{
     position: absolute;
     right: 0;
     left: 0;
     bottom: 0;
     padding: 20px 40px;
+    height: 60px;
     background-color: $bordercolor;
 
     &__body{
       position: relative;
       float: left;
-      width: calc(100% - 115px);
+      width: calc(100% - 125px);
       height: 50px;
 
       .text{
@@ -98,37 +109,32 @@
         width: 100%;
         border: none;
         padding-left: 10px;
-
       }
-    }
 
       &__image{
         position: absolute;
         top: 0;
         right: 0;
-        display: inline-block;
         height: 50px;
         line-height: 50px;
         cursor: pointer;
-        text-align: center;
-        width: 40px;
 
         .set_image{
           display: none;
         }
       }
+    }
 
   input.send{
-    display: inline-block;
-    float: right;
+    display: block;
+    float: left;
     width: 100px;
-    line-height: 50px;
+    height: 50px;
     text-align: center;
-    margin-left: 15px;
+    margin-left: 25px;
     background-color: $Bluecolor;
     border: none;
     color: $Whitecolor;
-    padding: 0;
   }
  }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     root_path
   end
+
+  def after_sign_out_path_for(resource)
+    new_user_session_path
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,24 +1,31 @@
 class GroupsController < ApplicationController
 
+  def index
+    @groups = current_user.groups
+  end
+
   def new
     @group = Group.new
     @users = User.where.not(id: current_user)
   end
 
-  def edit
-    @group = Group.find(params[:id])
-  end
-
   def create
     @group = Group.new(group_params)
-     if current_user.name
-        @group.save
+      current_user.name
+     if @group.save
         redirect_to root_path, notice: '新しいグループを作成しました'
     else
       flash[:alert] = 'グループ作成に失敗しました'
       render new_group_path
     end
   end
+
+   def edit
+    @group = Group.includes(:users).find(params[:id])
+   end
+
+   def update
+   end
 
   private
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,6 +5,10 @@ class GroupsController < ApplicationController
     @users = User.where.not(id: current_user)
   end
 
+  def edit
+    @group = Group.find(params[:id])
+  end
+
   def create
     @group = Group.new(group_params)
      if current_user.name
@@ -12,7 +16,7 @@ class GroupsController < ApplicationController
         redirect_to root_path, notice: '新しいグループを作成しました'
     else
       flash[:alert] = 'グループ作成に失敗しました'
-      render :new
+      render new_group_path
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -11,7 +11,6 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
-      current_user.name
      if @group.save
         redirect_to root_path, notice: '新しいグループを作成しました'
     else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,8 @@
 class MessagesController < ApplicationController
 
   def index
+    @user = User.find(current_user.id)
+    @groups = @user.groups
   end
 
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,10 @@
 class MessagesController < ApplicationController
 
   def index
-    @user = User.find(current_user.id)
-    @groups = @user.groups
+    @groups = current_user.groups
+    @group = Group.find_by(params[:group_id])
+    @messages = @group.messages
+    @users = @group.users
   end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-
+  validates :name, :users, presence: true
   has_many :messages
   has_many :group_users
   has_many :users, through: :group_users

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  has_many :messages
   has_many :group_users
   has_many :groups, through: :group_users
 

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @group, class: "new_chat_group", id: "new_chat_group" do |f|
+= form_for @group  do |f|
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "グループ名", class: "chat-group-form__label", for: "chat_group_name"
@@ -18,7 +18,7 @@
           #chat-group-user-22.chat-group-user.clearfix
             %p.chat-group-user__name
               = current_user.name
-              = f.collection_check_boxes(:user_ids, @users, :id, :name)
+              = f.collection_check_boxes(:user_ids, User.where.not(id: current_user), :id, :name)
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right

--- a/app/views/groups/_group_form.html.haml
+++ b/app/views/groups/_group_form.html.haml
@@ -1,0 +1,25 @@
+= form_for @group, class: "new_chat_group", id: "new_chat_group" do |f|
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label "グループ名", class: "chat-group-form__label", for: "chat_group_name"
+    .chat-group-form__field--right
+      = f.text_field :name, id: "chat_group_name",  placeholder: "グループ名を入力してください", class: "chat-group-form__input"
+    / .chat-group-form__field.clearfix
+    /   .chat-group-form__field--left
+    /     = f.label :name, "チャットメンバーを追加", class: "chat-group-form__label"
+    /   .chat-group-form__field--right
+    /     .chat-group-form__search.clearfix
+    /       = f.text_field :name, id: "user-search-field", placeholder: "追加したいユーザー名を入力してください", class: "chat-group-form__input"
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+        = f.label :name, "チャットメンバー", class: "chat-group-form__label"
+      .chat-group-form__field--right
+        #chat-group-users
+          #chat-group-user-22.chat-group-user.clearfix
+            %p.chat-group-user__name
+              = current_user.name
+              = f.collection_check_boxes(:user_ids, @users, :id, :name)
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        = f.submit "Save", class: "chat-group-form__action-btn"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,25 +1,5 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", action: "/chat_groups/22", method: "post"}
-    %input{name: "utf8", type: "hidden", value: "✓"}
-    %input{name: "_method", type: "hidden", value: "patch"}
-    %input{name: "authenticity_token", type: "hidden", value: "U5ABp0/UobRQTSwsR0V40bX1w3t0rZ0CTqrVyLecD+L6sdhBRO/gVcKy7w/Rgxnc7Hf0Ts39996dal3to5fTag=="}
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-      .chat-group-form__field--right
-        .chat-group-form__search.clearfix
-          %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}
-        #user-search-result
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", name: "commit", type: "submit", value: "Save"}
+
+  = render 'group_form'
+

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,27 +1,4 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group, class: "new_chat_group", id: "new_chat_group" do |f|
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label "グループ名", class: "chat-group-form__label", for: "chat_group_name"
-      .chat-group-form__field--right
-        = f.text_field :name, id: "chat_group_name",  placeholder: "グループ名を入力してください", class: "chat-group-form__input"
-    / .chat-group-form__field.clearfix
-    /   .chat-group-form__field--left
-    /     = f.label :name, "チャットメンバーを追加", class: "chat-group-form__label"
-    /   .chat-group-form__field--right
-    /     .chat-group-form__search.clearfix
-    /       = f.text_field :name, id: "user-search-field", placeholder: "追加したいユーザー名を入力してください", class: "chat-group-form__input"
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, "チャットメンバー", class: "chat-group-form__label"
-      .chat-group-form__field--right
-        #chat-group-users
-          #chat-group-user-22.chat-group-user.clearfix
-            %p.chat-group-user__name
-              = current_user.name
-              = f.collection_check_boxes(:user_ids, @users, :id, :name)
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit "Save", class: "chat-group-form__action-btn"
+
+  = render 'group_form'

--- a/app/views/messages/_leftside.html.haml
+++ b/app/views/messages/_leftside.html.haml
@@ -1,0 +1,6 @@
+-@groups.each do |group|
+  %li.conversation__group
+    = link_to "#",class: "conversation__group__link" do
+      %p.conversation__group__name
+      = group.name
+      %p.conversation__group__chat-message sample

--- a/app/views/messages/_leftside.html.haml
+++ b/app/views/messages/_leftside.html.haml
@@ -1,6 +1,6 @@
 -@groups.each do |group|
   %li.conversation__group
-    =link_to "/groups/#{group.id}/messages",class: "conversation__group__link" do
+    =link_to group_messages_path(@group.id), class: "conversation__group__link" do
       %p.conversation__group__name
         = group.name
       %p.conversation__group__chat-message aa

--- a/app/views/messages/_leftside.html.haml
+++ b/app/views/messages/_leftside.html.haml
@@ -1,6 +1,6 @@
 -@groups.each do |group|
   %li.conversation__group
-    = link_to "#",class: "conversation__group__link" do
+    =link_to "/groups/#{group.id}/messages",class: "conversation__group__link" do
       %p.conversation__group__name
-      = group.name
-      %p.conversation__group__chat-message sample
+        = group.name
+      %p.conversation__group__chat-message aa

--- a/app/views/messages/_leftside.html.haml
+++ b/app/views/messages/_leftside.html.haml
@@ -1,6 +1,5 @@
--@groups.each do |group|
-  %li.conversation__group
-    =link_to group_messages_path(@group.id), class: "conversation__group__link" do
-      %p.conversation__group__name
-        = group.name
-      %p.conversation__group__chat-message aa
+%li.conversation__group
+  =link_to group_messages_path(@group.id), class: "conversation__group__link" do
+    %p.conversation__group__name
+      = leftside.name
+    %p.conversation__group__chat-message aa

--- a/app/views/messages/_rightside.html.haml
+++ b/app/views/messages/_rightside.html.haml
@@ -1,0 +1,10 @@
+.right-content__middle
+  %ul.message
+    %li.message__contents.cleafix
+      %p.message__contents__sender sample
+      %p.message__contents__time 2017/02/10 00:00:00
+      %p.message__contents__content aa
+    %li.message__contents.cleafix
+      %p.message__contents__sender sample
+      %p.message__contents__time 2017/02/10 00:00:00
+      %p.message__contents__content aa

--- a/app/views/messages/_rightside.html.haml
+++ b/app/views/messages/_rightside.html.haml
@@ -1,10 +1,8 @@
-.right-content__middle
-  %ul.message
-    %li.message__contents.cleafix
-      %p.message__contents__sender sample
-      %p.message__contents__time 2017/02/10 00:00:00
-      %p.message__contents__content aa
-    %li.message__contents.cleafix
-      %p.message__contents__sender sample
-      %p.message__contents__time 2017/02/10 00:00:00
-      %p.message__contents__content aa
+%li.message__contents.cleafix
+  %p.message__contents__sender sample
+  %p.message__contents__time 2017/02/10 00:00:00
+  %p.message__contents__content aa
+%li.message__contents.cleafix
+  %p.message__contents__sender sample
+  %p.message__contents__time 2017/02/10 00:00:00
+  %p.message__contents__content aa

--- a/app/views/messages/_righttop.html.haml
+++ b/app/views/messages/_righttop.html.haml
@@ -1,3 +1,2 @@
--@users. each do |user|
-  %li.chat-members__members
-    = user.name
+%li.chat-members__members
+  = righttop.name

--- a/app/views/messages/_righttop.html.haml
+++ b/app/views/messages/_righttop.html.haml
@@ -1,0 +1,3 @@
+-@users. each do |user|
+  %li.chat-members__members
+    = user.name

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,7 +1,8 @@
 .wrapper
   .left-content
     .left-content-top.clearfix
-      %p.left-content-top__user-name sample
+      %p.left-content-top__user-name
+        = current_user.name
       .left-content-top__set
         = link_to new_group_path, class: "left-content-top__setting" do
           %i.fa.fa-pencil-square-o.fa-lg
@@ -10,14 +11,14 @@
 
 
     .left-contant-bottom
-      %li.group
-        = link_to "",class: "group__link" do
-          %p.group__name sample
-          %p.group__chat-message aa
-      %li.group
-        = link_to "",class: "group__link" do
-          %p.group__name sample
-          %p.group__chat-message aa
+      %ul.conversation
+      -@groups.each do |group|
+        %li.conversation__group
+          = link_to "#",class: "conversation__group__link" do
+            %p.conversation__group__name
+            = group.name
+            %p.conversation__group__chat-message sample
+
 
   .right-content.clearfix
 
@@ -26,7 +27,7 @@
       .right-content__edit
         = link_to "#",class: "edit-link" do
           %p.edit-button Edit
-      %p.chat-members.clearfix Members: aa aa
+      %ul.chat-members.clearfix Members: aa aa
 
     .right-content__middle
       %ul.message
@@ -45,5 +46,5 @@
         %input.text{row: "1", placeholder: "type a message", name: "message[body]", id: "message_body"}
         %label.chat-footer__image
           %set_image{type: "file", name: "message[image]", id: "message_image"}
-          = fa_icon "image"
+          %i.fa.fa-image
       %input.send{type: "submit", value: "Send"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -20,13 +20,11 @@
       %p.chat-group.clearfix
         = @group.name
       .right-content__edit
-        = link_to edit_group_path(@group),class: "edit-link" do
+        = link_to edit_group_path(@group), class: "edit-link" do
           %p.edit-button Edit
       %ul.chat-members.clearfix
         %li.chat-members__members Members:
-        -@users. each do |user|
-          %li.chat-members__members
-            = user.name
+        = render 'righttop'
 
     .right-content__middle
       %ul.message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,12 +11,8 @@
 
     .left-content-bottom
       %ul.conversation
-        -@groups.each do |group|
-          %li.conversation__group
-            =link_to "/groups/#{group.id}/messages",class: "conversation__group__link" do
-              %p.conversation__group__name
-                = group.name
-              %p.conversation__group__chat-message aa
+        = render 'leftside'
+
 
   .right-content.clearfix
 
@@ -34,10 +30,8 @@
 
     .right-content__middle
       %ul.message
-        %li.message__contents.clearfix
-          %p.message__contents__sender test
-          %p.message__contents__time 2222222
-          %p.message__contents__content なんでやねん
+        = render 'rightside'
+
 
     .right-content__chat-footer.clearfix
       %form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -12,12 +12,7 @@
 
     .left-contant-bottom
       %ul.conversation
-      -@groups.each do |group|
-        %li.conversation__group
-          = link_to "#",class: "conversation__group__link" do
-            %p.conversation__group__name
-            = group.name
-            %p.conversation__group__chat-message sample
+        = render 'leftside'
 
 
   .right-content.clearfix
@@ -25,20 +20,11 @@
     .right-content__top.cleafix
       %p.chat-group.clearfix sample
       .right-content__edit
-        = link_to "#",class: "edit-link" do
+        = link_to "/groups/#{params[:group_id]}/edit",class: "edit-link" do
           %p.edit-button Edit
       %ul.chat-members.clearfix Members: aa aa
+      = render 'rightside'
 
-    .right-content__middle
-      %ul.message
-        %li.message__contents.cleafix
-          %p.message__contents__sender sample
-          %p.message__contents__time 2017/02/10 00:00:00
-          %p.message__contents__content aa
-        %li.message__contents.cleafix
-          %p.message__contents__sender sample
-          %p.message__contents__time 2017/02/10 00:00:00
-          %p.message__contents__content aa
 
     .chat-footer
       %form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,7 @@
 
     .left-content-bottom
       %ul.conversation
-        = render 'leftside'
+        = render partial: 'messages/leftside', collection: @groups
 
 
   .right-content.clearfix
@@ -24,11 +24,11 @@
           %p.edit-button Edit
       %ul.chat-members.clearfix
         %li.chat-members__members Members:
-        = render 'righttop'
+        = render partial: 'messages/righttop', collection: @users
 
     .right-content__middle
       %ul.message
-        = render 'rightside'
+        = render partial: 'messages/rightside'
 
 
     .right-content__chat-footer.clearfix

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,36 +1,49 @@
 .wrapper
   .left-content
-    .left-content-top.clearfix
+    .left-content-top
       %p.left-content-top__user-name
         = current_user.name
-      .left-content-top__set
-        = link_to new_group_path, class: "left-content-top__setting" do
-          %i.fa.fa-pencil-square-o.fa-lg
-        = link_to edit_user_registration_path, class: "left-content-top__setting" do
-          %i.fa.fa-cog.fa-lg
+        .left-content-top__set.clearfix
+          = link_to new_group_path, class: "left-content-top__setting" do
+            %i.fa.fa-pencil-square-o.fa-lg
+          = link_to edit_user_registration_path, class: "left-content-top__setting" do
+            %i.fa.fa-cog.fa-lg
 
-
-    .left-contant-bottom
+    .left-content-bottom
       %ul.conversation
-        = render 'leftside'
-
+        -@groups.each do |group|
+          %li.conversation__group
+            =link_to "/groups/#{group.id}/messages",class: "conversation__group__link" do
+              %p.conversation__group__name
+                = group.name
+              %p.conversation__group__chat-message aa
 
   .right-content.clearfix
 
     .right-content__top.cleafix
-      %p.chat-group.clearfix sample
+      %p.chat-group.clearfix
+        = @group.name
       .right-content__edit
-        = link_to "/groups/#{params[:group_id]}/edit",class: "edit-link" do
+        = link_to edit_group_path(@group),class: "edit-link" do
           %p.edit-button Edit
-      %ul.chat-members.clearfix Members: aa aa
-      = render 'rightside'
+      %ul.chat-members.clearfix
+        %li.chat-members__members Members:
+        -@users. each do |user|
+          %li.chat-members__members
+            = user.name
 
+    .right-content__middle
+      %ul.message
+        %li.message__contents.clearfix
+          %p.message__contents__sender test
+          %p.message__contents__time 2222222
+          %p.message__contents__content なんでやねん
 
-    .chat-footer
+    .right-content__chat-footer.clearfix
       %form
-      .label.chat-footer__body
-        %input.text{row: "1", placeholder: "type a message", name: "message[body]", id: "message_body"}
-        %label.chat-footer__image
-          %set_image{type: "file", name: "message[image]", id: "message_image"}
-          %i.fa.fa-image
-      %input.send{type: "submit", value: "Send"}
+        .right-content__chat-footer__body
+          %input.text{type:"text", placeholder:"type a message"}
+            %label.right-content__chat-footer__body__image
+              %input.set_image{type: "file"}
+                =fa_icon "image"
+        %input.send{type:"submit", value:"Send"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'messages#index'
-  resources :groups, only: %i(new edit create) do
+  resources :groups, only: %i(index new edit create update) do
     resources :messages, only: %i(index)
   end
 end

--- a/db/migrate/20170219061619_create_messages.rb
+++ b/db/migrate/20170219061619_create_messages.rb
@@ -1,7 +1,7 @@
 class CreateMessages < ActiveRecord::Migration[5.0]
   def change
     create_table :messages do |t|
-      t.text :text,      null:false
+      t.text :body,      null:false
       t.string :image
       t.references :group,   foreign_key: true
       t.references :user,    foreign_key: true

--- a/db/migrate/20170219061619_create_messages.rb
+++ b/db/migrate/20170219061619_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.text :text,      null:false
+      t.string :image
+      t.references :group,   foreign_key: true
+      t.references :user,    foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170214033243) do
+ActiveRecord::Schema.define(version: 20170219061619) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20170214033243) do
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text     "text",       limit: 65535, null: false
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -47,4 +58,6 @@ ActiveRecord::Schema.define(version: 20170214033243) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20170219061619) do
   end
 
   create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.text     "text",       limit: 65535, null: false
+    t.text     "body",       limit: 65535
     t.string   "image"
     t.integer  "group_id"
     t.integer  "user_id"


### PR DESCRIPTION
# WHAT
・グループ作成、編集の部分テンプレートの実装
・チャットグループ覧、チャットメッセージ覧の部分テンプレートの実装
・Editボタンから編集画面に移行
・左上にログインしているユーザーの名前の表示
・サイドバーに作成したグループの表示
・サイドバークリックでgroup_idのmessageに移動
・右上にグループの名前と参加しているユーザーの名前を表示
・レイアウトの修正
# WHY
・チャットグループ作成に必要な機能ため